### PR TITLE
Applications

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -110,6 +110,7 @@ The following relationships are created/mapped:
 | `okta_account`        | **HAS**               | `okta_application`    |
 | `okta_account`        | **HAS**               | `okta_user`           |
 | `okta_account`        | **HAS**               | `okta_user_group`     |
+| `okta_user`           | **ASSIGNED**          | `okta_application`    |
 | `okta_user`           | **ASSIGNED**          | `mfa_device`          |
 | `okta_user_group`     | **ASSIGNED**          | `okta_application`    |
 | `okta_user_group`     | **HAS**               | `okta_user`           |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -95,6 +95,7 @@ The following entities are created:
 | ------------------ | --------------------- | --------------- |
 | Okta Account       | `okta_account`        | `Account`       |
 | Okta App UserGroup | `okta_app_user_group` | `UserGroup`     |
+| Okta Application   | `okta_application`    | `Application`   |
 | Okta Factor Device | `mfa_device`          | `Key`           |
 | Okta User          | `okta_user`           | `User`          |
 | Okta UserGroup     | `okta_user_group`     | `UserGroup`     |
@@ -106,6 +107,7 @@ The following relationships are created/mapped:
 | Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
 | --------------------- | --------------------- | --------------------- |
 | `okta_account`        | **HAS**               | `okta_app_user_group` |
+| `okta_account`        | **HAS**               | `okta_application`    |
 | `okta_account`        | **HAS**               | `okta_user`           |
 | `okta_account`        | **HAS**               | `okta_user_group`     |
 | `okta_user`           | **ASSIGNED**          | `mfa_device`          |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -111,6 +111,7 @@ The following relationships are created/mapped:
 | `okta_account`        | **HAS**               | `okta_user`           |
 | `okta_account`        | **HAS**               | `okta_user_group`     |
 | `okta_user`           | **ASSIGNED**          | `mfa_device`          |
+| `okta_user_group`     | **ASSIGNED**          | `okta_application`    |
 | `okta_user_group`     | **HAS**               | `okta_user`           |
 
 <!--

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,6 @@ import {
   OktaUser,
   OktaUserGroup,
   OktaApplication,
-  OktaApplicationGroup,
 } from './okta/types';
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,14 @@ import {
 import { IntegrationConfig } from './config';
 export type ResourceIteratee<T> = (each: T) => Promise<void> | void;
 import createOktaClient from './okta/createOktaClient';
-import { OktaClient, OktaFactor, OktaUser, OktaUserGroup } from './okta/types';
+import {
+  OktaClient,
+  OktaFactor,
+  OktaUser,
+  OktaUserGroup,
+  OktaApplication,
+  OktaApplicationGroup,
+} from './okta/types';
 
 /**
  * An APIClient maintains authentication state and provides an interface to
@@ -82,6 +89,26 @@ export class APIClient {
     }
   }
 
+  /**
+   * Iterates each application resource in the provider.
+   *
+   * @param iteratee receives each resource to produce entities/relationships
+   */
+  public async iterateApplications(
+    iteratee: ResourceIteratee<OktaApplication>,
+  ): Promise<void> {
+    const apps: OktaApplication[] = [];
+    await this.oktaClient.listApplications().each((e) => {
+      apps.push(e);
+      console.log(e); //TODO remove this line
+    });
+
+    for (const app of apps) {
+      await iteratee(app);
+    }
+  }
+
+  //retrieves the group ids that a user belongs to
   public async getGroupsForUser(id) {
     const groupIds: string[] = [];
     await this.oktaClient.listUserGroups(id).each((e) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -100,7 +100,6 @@ export class APIClient {
     const apps: OktaApplication[] = [];
     await this.oktaClient.listApplications().each((e) => {
       apps.push(e);
-      console.log(e); //TODO remove this line
     });
 
     for (const app of apps) {
@@ -109,21 +108,39 @@ export class APIClient {
   }
 
   //retrieves the group ids that a user belongs to
-  public async getGroupsForUser(id) {
+  public async getGroupsForUser(userId) {
     const groupIds: string[] = [];
-    await this.oktaClient.listUserGroups(id).each((e) => {
+    await this.oktaClient.listUserGroups(userId).each((e) => {
       groupIds.push(e.id);
     });
     return groupIds;
   }
 
   //retrieves any MFA (multi-factor authentication) devices assigned to user
-  public async getDevicesForUser(id) {
+  public async getDevicesForUser(userId) {
     const devices: OktaFactor[] = [];
-    await this.oktaClient.listFactors(id).each((e) => {
+    await this.oktaClient.listFactors(userId).each((e) => {
       devices.push(e);
     });
     return devices;
+  }
+
+  //retrieves any user group ids assigned to this application
+  public async getGroupsForApp(appId) {
+    const groupIds: string[] = [];
+    await this.oktaClient.listApplicationGroupAssignments(appId).each((e) => {
+      groupIds.push(e.id);
+    });
+    return groupIds;
+  }
+
+  //retrieves any individual user ids assigned to this application
+  public async getUsersForApp(appId) {
+    const userIds: string[] = [];
+    await this.oktaClient.listApplicationUsers(appId).each((e) => {
+      userIds.push(e.id);
+    });
+    return userIds;
   }
 }
 

--- a/src/steps/applications.ts
+++ b/src/steps/applications.ts
@@ -5,13 +5,24 @@ import {
   IntegrationStep,
   IntegrationStepExecutionContext,
   RelationshipClass,
-  //parseTimePropertyValue,
-  //IntegrationMissingKeyError,
+  IntegrationMissingKeyError,
 } from '@jupiterone/integration-sdk-core';
-
+import * as url from 'url';
 import { createAPIClient } from '../client';
 import { IntegrationConfig } from '../config';
 import { DATA_ACCOUNT_ENTITY } from './account';
+import { USER_GROUP_ENTITY_TYPE } from './access';
+
+import buildAppShortName from '../util/buildAppShortName';
+import getOktaAccountInfo from '../util/getOktaAccountInfo';
+import getOktaAccountAdminUrl from '../util/getOktaAccountAdminUrl';
+import {
+  getAccountName,
+  getVendorName,
+  isMultiInstanceApp,
+} from '../util/knownVendors';
+
+import { OktaIntegrationConfig } from '../types';
 
 export const APPLICATION_ENTITY_TYPE = 'okta_application';
 
@@ -25,41 +36,93 @@ export async function fetchApplications({
   const accountEntity = (await jobState.getData(DATA_ACCOUNT_ENTITY)) as Entity;
 
   await apiClient.iterateApplications(async (app) => {
-    /*const webLink = url.resolve(
-      getOktaAccountAdminUrl(instance.config),
-      `/admin/group/${group.id}`,
-    );*/
-    /*const entityType =
-      group.type === 'APP_GROUP'
-        ? APP_USER_GROUP_ENTITY_TYPE
-        : USER_GROUP_ENTITY_TYPE;*/
+    const webLink = url.resolve(
+      getOktaAccountAdminUrl(instance.config as OktaIntegrationConfig),
+      `/admin/app/${app.name}/instance/${app.id}`,
+    );
+
+    let imageUrl;
+    let loginUrl;
+
+    if (app._links?.logo) {
+      //the original said:
+      //  imageUrl = [app._links.logo].flat()[0].href;
+      // but TypeScript is complaining that flat() dne
+      //TODO : are there really nested arrays in some cases?
+      // And if so, how best to flatten them in this case?
+      imageUrl = app._links?.logo[0].href;
+    }
+
+    if (app._links?.appLinks) {
+      //const links = [app._links.appLinks].flat();
+      //const link = links.find((l) => l.name === 'login') || links[0];
+      // loginUrl = link && link.href;
+      //same typescript error as in .logo
+      const link = app._links?.appLinks[0];
+      loginUrl = link && link.href;
+    }
+
+    const oktaAccountInfo = getOktaAccountInfo(instance);
+    const appShortName = buildAppShortName(oktaAccountInfo, app.name);
+
+    const assignData = {
+      _key: app.id,
+      _type: APPLICATION_ENTITY_TYPE,
+      _class: 'Application',
+      id: app.id,
+      displayName: app.label || app.name || app.id,
+      name: app.name || app.label,
+      shortName: appShortName,
+      label: app.label,
+      status: app.status,
+      active: app.status === 'ACTIVE',
+      lastUpdated: app.lastUpdated,
+      created: app.created,
+      features: app.features,
+      signOnMode: app.signOnMode,
+      appVendorName: getVendorName(appShortName),
+      appAccountType: getAccountName(appShortName),
+      isMultiInstanceApp: isMultiInstanceApp(appShortName),
+      isSAMLApp: !!app.signOnMode && app.signOnMode.startsWith('SAML'),
+      webLink,
+      imageUrl,
+      loginUrl,
+    };
+
+    const appSettings = app.settings && app.settings.app;
+    if (appSettings) {
+      if (appSettings.awsEnvironmentType === 'aws.amazon') {
+        if (appSettings.identityProviderArn) {
+          const awsAccountIdMatch = /^arn:aws:iam::([0-9]+):/.exec(
+            appSettings.identityProviderArn,
+          );
+          if (awsAccountIdMatch) {
+            assignData['awsAccountId'] = awsAccountIdMatch[1];
+            assignData['appAccountId'] = awsAccountIdMatch[1];
+          }
+        }
+
+        assignData['awsIdentityProviderArn'] = appSettings.identityProviderArn;
+        assignData['awsEnvironmentType'] = appSettings.awsEnvironmentType;
+        assignData['awsGroupFilter'] = appSettings.groupFilter;
+        assignData['awsRoleValuePattern'] = appSettings.roleValuePattern;
+        assignData['awsJoinAllRoles'] = appSettings.joinAllRoles;
+        assignData['awsSessionDuration'] = appSettings.sessionDuration;
+      } else if (appSettings.githubOrg) {
+        assignData['githubOrg'] = appSettings.githubOrg;
+        assignData['appAccountId'] = appSettings.githubOrg;
+      } else if (appSettings.domain) {
+        // Google Cloud Platform and G Suite apps use `domain` as the account identifier
+        assignData['appDomain'] = appSettings.domain;
+        assignData['appAccountId'] = appSettings.domain;
+      }
+    }
 
     const appEntity = await jobState.addEntity(
       createIntegrationEntity({
         entityData: {
           source: app,
-          assign: {
-            _key: app.id,
-            _type: APPLICATION_ENTITY_TYPE,
-            _class: 'Application',
-            id: app.id,
-            /*webLink: webLink,
-            displayName: group.profile.name,
-            created: parseTimePropertyValue(group.created)!,
-            createdOn: parseTimePropertyValue(group.created)!,
-            lastUpdated: parseTimePropertyValue(group.lastUpdated)!,
-            lastUpdatedOn: parseTimePropertyValue(group.lastUpdated)!,
-            lastMembershipUpdated: parseTimePropertyValue(
-              group.lastMembershipUpdated,
-            )!,
-            lastMembershipUpdatedOn: parseTimePropertyValue(
-              group.lastMembershipUpdated,
-            )!,
-            objectClass: group.objectClass,
-            type: group.type,
-            name: group.profile.name,
-            description: group.profile.description,*/
-          },
+          assign: { ...assignData },
         },
       }),
     );
@@ -72,6 +135,26 @@ export async function fetchApplications({
         to: appEntity,
       }),
     );
+
+    //assign the groups that use this app
+    const groupIds = await apiClient.getGroupsForApp(app.id);
+    for (const groupId of groupIds || []) {
+      const groupEntity = await jobState.findEntity(groupId);
+
+      if (!groupEntity) {
+        throw new IntegrationMissingKeyError(
+          `Expected group with key to exist (key=${groupId})`,
+        );
+      }
+
+      await jobState.addRelationship(
+        createDirectRelationship({
+          _class: RelationshipClass.ASSIGNED,
+          from: groupEntity,
+          to: appEntity,
+        }),
+      );
+    }
   });
 }
 export const applicationSteps: IntegrationStep<IntegrationConfig>[] = [
@@ -92,8 +175,14 @@ export const applicationSteps: IntegrationStep<IntegrationConfig>[] = [
         sourceType: 'okta_account',
         targetType: APPLICATION_ENTITY_TYPE,
       },
+      {
+        _type: 'okta_user_group_assigned_application',
+        _class: RelationshipClass.ASSIGNED,
+        sourceType: USER_GROUP_ENTITY_TYPE,
+        targetType: APPLICATION_ENTITY_TYPE,
+      },
     ],
-    dependsOn: ['fetch-account'],
+    dependsOn: ['fetch-users'],
     executionHandler: fetchApplications,
   },
 ];

--- a/src/steps/applications.ts
+++ b/src/steps/applications.ts
@@ -1,0 +1,99 @@
+import {
+  createDirectRelationship,
+  createIntegrationEntity,
+  Entity,
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  RelationshipClass,
+  //parseTimePropertyValue,
+  //IntegrationMissingKeyError,
+} from '@jupiterone/integration-sdk-core';
+
+import { createAPIClient } from '../client';
+import { IntegrationConfig } from '../config';
+import { DATA_ACCOUNT_ENTITY } from './account';
+
+export const APPLICATION_ENTITY_TYPE = 'okta_application';
+
+export async function fetchApplications({
+  instance,
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<IntegrationConfig>) {
+  const apiClient = createAPIClient(instance.config, logger);
+
+  const accountEntity = (await jobState.getData(DATA_ACCOUNT_ENTITY)) as Entity;
+
+  await apiClient.iterateApplications(async (app) => {
+    /*const webLink = url.resolve(
+      getOktaAccountAdminUrl(instance.config),
+      `/admin/group/${group.id}`,
+    );*/
+    /*const entityType =
+      group.type === 'APP_GROUP'
+        ? APP_USER_GROUP_ENTITY_TYPE
+        : USER_GROUP_ENTITY_TYPE;*/
+
+    const appEntity = await jobState.addEntity(
+      createIntegrationEntity({
+        entityData: {
+          source: app,
+          assign: {
+            _key: app.id,
+            _type: APPLICATION_ENTITY_TYPE,
+            _class: 'Application',
+            id: app.id,
+            /*webLink: webLink,
+            displayName: group.profile.name,
+            created: parseTimePropertyValue(group.created)!,
+            createdOn: parseTimePropertyValue(group.created)!,
+            lastUpdated: parseTimePropertyValue(group.lastUpdated)!,
+            lastUpdatedOn: parseTimePropertyValue(group.lastUpdated)!,
+            lastMembershipUpdated: parseTimePropertyValue(
+              group.lastMembershipUpdated,
+            )!,
+            lastMembershipUpdatedOn: parseTimePropertyValue(
+              group.lastMembershipUpdated,
+            )!,
+            objectClass: group.objectClass,
+            type: group.type,
+            name: group.profile.name,
+            description: group.profile.description,*/
+          },
+        },
+      }),
+    );
+
+    //TODO: change the below to be right
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.HAS,
+        from: accountEntity,
+        to: appEntity,
+      }),
+    );
+  });
+}
+export const applicationSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: 'fetch-applications',
+    name: 'Fetch Applications',
+    entities: [
+      {
+        resourceName: 'Okta Application',
+        _type: APPLICATION_ENTITY_TYPE,
+        _class: 'Application',
+      },
+    ],
+    relationships: [
+      {
+        _type: 'okta_account_has_application',
+        _class: RelationshipClass.HAS,
+        sourceType: 'okta_account',
+        targetType: APPLICATION_ENTITY_TYPE,
+      },
+    ],
+    dependsOn: ['fetch-account'],
+    executionHandler: fetchApplications,
+  },
+];

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -1,6 +1,7 @@
 import { accountSteps } from './account';
 import { accessSteps } from './access';
+import { applicationSteps } from './applications';
 
-const integrationSteps = [...accountSteps, ...accessSteps];
+const integrationSteps = [...accountSteps, ...accessSteps, ...applicationSteps];
 
 export { integrationSteps };


### PR DESCRIPTION
Hello @aiwilliams !

Here is the main part of adding Applications to the Okta integration. It includes the apps and the user/group assignments to them, but it does not yet include the global mapping to the AWS IAM roles. (At least, I think those are meant to be global mappings, similar to the global map to CVEs in Cobalt, right?)

There are two small differences between this code and original behavior:
1) The old pattern had a relationship `okta_group_assigned_application`, but the new SDK expects  `okta_user_group_assigned_application` based on the names of the entities (in both the old and new integration).

2) Per my comments on lines 47-63 in application.ts, TypeScript on my machine didn't like the old syntax (even in the old code) and I'm not sure why. I coded around it to get things to run, but I haven't really covered the case where we get nested arrays back, which the old code seems to account for. If that's a real possibility, I could use some help here on the best destructuring syntax to use.

Kevin